### PR TITLE
Stop escaping HTML in JSON output

### DIFF
--- a/.github/workflows/gorelease.yml
+++ b/.github/workflows/gorelease.yml
@@ -8,7 +8,7 @@ jobs:
   gorelease:
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.17.x ]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -38,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           header: gorelease
           message: |
-            ### Exported API Changes Report
+            ### API Changes
 
             <pre>
             ${{ steps.gorelease.outputs.report }}

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -14,7 +14,7 @@ jobs:
     name: Upload Release Assets
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.17.x ]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x ]
+        go-version: [ 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x ]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-cache
       - name: Restore base test coverage
-        if: matrix.go-version == '1.16.x'
+        if: matrix.go-version == '1.17.x'
         uses: actions/cache@v2
         with:
           path: |
@@ -43,13 +43,13 @@ jobs:
           # Use base sha for PR or new commit hash for master/main push in test result key.
           key: ${{ runner.os }}-unit-test-coverage-${{ (github.event.pull_request.base.sha != github.event.after) && github.event.pull_request.base.sha || github.event.after }}
       - name: Checkout base code
-        if: matrix.go-version == '1.16.x' && env.RUN_BASE_COVERAGE == 'on' && steps.benchmark-base.outputs.cache-hit != 'true' && github.event.pull_request.base.sha != ''
+        if: matrix.go-version == '1.17.x' && env.RUN_BASE_COVERAGE == 'on' && steps.benchmark-base.outputs.cache-hit != 'true' && github.event.pull_request.base.sha != ''
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: __base
       - name: Run test for base code
-        if: matrix.go-version == '1.16.x' && env.RUN_BASE_COVERAGE == 'on' && steps.benchmark-base.outputs.cache-hit != 'true' && github.event.pull_request.base.sha != ''
+        if: matrix.go-version == '1.17.x' && env.RUN_BASE_COVERAGE == 'on' && steps.benchmark-base.outputs.cache-hit != 'true' && github.event.pull_request.base.sha != ''
         run: |
           cd __base
           make | grep test-unit && (make test-unit && go tool cover -func=./unit.coverprofile | sed -e 's/.go:[0-9]*:\t/.go\t/g' | sed -e 's/\t\t*/\t/g'  > ../unit-base.txt) || echo "No test-unit in base"
@@ -69,7 +69,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
         run: cp unit.txt unit-base.txt
       - name: Comment Test Coverage
-        if: matrix.go-version == '1.16.x'
+        if: matrix.go-version == '1.17.x'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
             </details>
 
       - name: Upload code coverage
-        if: matrix.go-version == '1.16.x'
+        if: matrix.go-version == '1.17.x'
         uses: codecov/codecov-action@v1
         with:
           file: ./unit.coverprofile

--- a/compact_test.go
+++ b/compact_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestMarshalIndentCompact(t *testing.T) {
 	// nolint:lll // Yeah, this line is loooong, but that's ok.
-	j := []byte(`{"openapi":"3.0.2","info":{"title":"","version":""},"paths":{"/test/{in-path}":{"post":{"summary":"Title","description":"","operationId":"name","x-some-array":["abc","def",123456,7890123456,[],{"foo":"bar"},"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"],"parameters":[{"name":"in_query","in":"query","schema":{"type":"integer"}},{"name":"in-path","in":"path","required":true,"schema":{"type":"boolean"}},{"name":"in_cookie","in":"cookie","schema":{"type":"number"}},{"name":"X-In-Header","in":"header","schema":{"type":"string"}}],"requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/FormDataOpenapiTestInput"}}}},"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{}}}}},"deprecated":true}}},"components":{"schemas":{"FormDataOpenapiTestInput":{"type":"object","properties":{"in_form_data":{"type":"string"}}}}}}`)
+	j := []byte(`{"openapi":"3.0.2","info":{"title":"","version":""},"paths":{"/test/{in-path}":{"post":{"summary":"Title","description":"","operationId":"name","x-some-array":["abc","def",123456,7890123456,[],{"foo":"bar"},"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!<>"],"parameters":[{"name":"in_query","in":"query","schema":{"type":"integer"}},{"name":"in-path","in":"path","required":true,"schema":{"type":"boolean"}},{"name":"in_cookie","in":"cookie","schema":{"type":"number"}},{"name":"X-In-Header","in":"header","schema":{"type":"string"}}],"requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/FormDataOpenapiTestInput"}}}},"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{}}}}},"deprecated":true}}},"components":{"schemas":{"FormDataOpenapiTestInput":{"type":"object","properties":{"in_form_data":{"type":"string"}}}}}}`)
 	v := orderedmap.New()
 	assert.NoError(t, json.Unmarshal(j, &v))
 
@@ -26,7 +26,7 @@ XXXYYYYYY"post":{
 XXXYYYYYYYY"summary":"Title","description":"","operationId":"name",
 XXXYYYYYYYY"x-some-array":[
 XXXYYYYYYYYYY"abc","def",123456,7890123456,[],{"foo":"bar"},
-XXXYYYYYYYYYY"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"
+XXXYYYYYYYYYY"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!<>"
 XXXYYYYYYYY],
 XXXYYYYYYYY"parameters":[
 XXXYYYYYYYYYY{"name":"in_query","in":"query","schema":{"type":"integer"}},
@@ -63,7 +63,7 @@ XXX}`, string(jjj))
         "summary":"Title","description":"","operationId":"name",
         "x-some-array":[
           "abc","def",123456,7890123456,[],{"foo":"bar"},
-          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!<>"
         ],
         "parameters":[
           {"name":"in_query","in":"query","schema":{"type":"integer"}},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/swaggest/assertjson
 go 1.11
 
 require (
-	github.com/bool64/dev v0.1.37
+	github.com/bool64/dev v0.1.41
 	github.com/bool64/shared v0.1.3
 	github.com/iancoleman/orderedmap v0.2.0
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/bool64/dev v0.1.25/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.1.37 h1:/c8U4emt4xjMDx8Au+POOYo5LJIw+Mzi4e48j5CmGQo=
 github.com/bool64/dev v0.1.37/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
+github.com/bool64/dev v0.1.41 h1:L554LCQZc3d7mtcdPUgDbSrCVbr48/30zgu0VuC/FTA=
+github.com/bool64/dev v0.1.41/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/shared v0.1.3 h1:gj7XZPYa1flQsCg3q9AIju+W2A1jaexK0fdFu2XtaG0=
 github.com/bool64/shared v0.1.3/go.mod h1:RF1p1Oi29ofgOvinBpetbF5mceOUP3kpMkvLbWOmtm0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
JSON produced by this lib is intended for use in tests and not in HTML pages, so HTML escaping hurts readability for no benefit. This PR disables HTML escaping in marshaled JSON.